### PR TITLE
 Solved the segmentation fault problem.

### DIFF
--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -100,7 +100,7 @@ int main(int argc, char **argv)
 	motor_on.call(t);
 
 	geometry_msgs::Twist msg;
-	pf.init();
+	//pf.init();
 	Rate loop_rate(10);
 	Action act = {0.0,0.0};
 	while(ok()){


### PR DESCRIPTION
When initializing the particle filter with replay.cpp, initialization before adding Episode caused a segmentation fault. (ParticleFilter.init)
This problem occurred when generating a uniformly distributed random number.
This problem was confirmed by Ubuntu Desktop 16,04. In Ubuntu Server 16.04 running on Raspberru Pi this problem did not occur but we confirmed that the generated random number returned values ​​outside the specified range.
As a solution to the problem, we did not initialize the particle filter before loading the Episode.
